### PR TITLE
Refactor: Modularize Category and Fix Seeders/Migrations

### DIFF
--- a/Modules/Category/database/migrations/2025_09_28_095014_create_category_posts_table.php
+++ b/Modules/Category/database/migrations/2025_09_28_095014_create_category_posts_table.php
@@ -13,7 +13,14 @@ return new class extends Migration
     {
         Schema::create('category_posts', function (Blueprint $table) {
             $table->id();
+            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('category_id');
             $table->timestamps();
+
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade');
+
+            $table->unique(['post_id', 'category_id']);
         });
     }
 

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $title = $this->faker->sentence(rand(3, 8));
+
+        return [
+            'user_id' => User::factory(),
+            'title' => $title,
+            'content' => $this->faker->paragraphs(rand(5, 15), true),
+            'excerpt' => $this->faker->paragraph(2),
+            'slug' => Str::slug($title) . '-' . uniqid(),
+            'published' => $this->faker->boolean(80), // 80% chance of being published
+            'published_at' => now(),
+            'views_count' => $this->faker->numberBetween(0, 10000),
+            'likes_count' => $this->faker->numberBetween(0, 5000),
+        ];
+    }
+}


### PR DESCRIPTION
This commit refactors the application by moving all category-related functionality into a dedicated 'Category' module and updates the database seeders and migrations to work with the new structure.

**Modularization:**
- Created a new `Modules/Category` directory and moved all relevant models, controllers, views, and migrations.
- Changed the relationship between Post and Category from one-to-many to many-to-many.
- Updated all dependent controllers (`PostController`, `HomeController`, `Admin\PostController`) and views to support the new modular structure.
- Created the necessary module configuration files (`module.json`, service providers, route files).
- Cleaned up the main application by removing old category-related files and routes.

**Database Seeding & Migrations:**
- Created a `CategorySeeder` within the `Category` module to populate default categories.
- Created a `PostFactory` to enable post creation during seeding.
- Created a `PostSeeder` to generate sample posts and randomly attach categories to them.
- Corrected the `create_category_posts_table` migration to include the required `post_id` and `category_id` foreign keys.
- Updated the main `DatabaseSeeder` to call the new seeders in the correct order.
- **Note to user:** The `spatie/laravel-permission` migration needs to be published manually by running `php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="permission-migrations"` before migrating.