### PR TITLE
Debug: Dump and Die Request Data to Resolve Validation Issue

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -40,6 +40,9 @@ class PostController extends Controller
 
     public function store(Request $request)
     {
+        // Forcefully dump the request data to debug the form submission issue.
+        dd($request->all());
+
         Log::info('Admin Post Store Request Data:', $request->all());
 
         $request->validate([
@@ -91,6 +94,9 @@ class PostController extends Controller
 
     public function update(Request $request, Post $post)
     {
+        // Forcefully dump the request data to debug the form submission issue.
+        dd($request->all());
+
         Log::info('Admin Post Update Request Data:', $request->all());
 
         $request->validate([


### PR DESCRIPTION
This commit adds a `dd($request->all())` statement to the beginning of the `store` and `update` methods in the `Admin/PostController`. This is a direct debugging approach to resolve a persistent validation issue where `category_ids` are not being recognized.

By dumping the request data immediately, we can definitively see the payload being sent from the form to the server, bypassing any potential issues with logging or other middleware. This will help isolate the problem to either the frontend form submission or the backend processing.